### PR TITLE
 Allow Delphi scripting from DLLs

### DIFF
--- a/zlog/UPluginManager.pas
+++ b/zlog/UPluginManager.pas
@@ -35,7 +35,7 @@ uses
 	UPackageLoader,
 	WinXCtrls,
 	Windows,
-   System.UITypes;
+	System.UITypes;
 
 type
 	TMarketItem = class(TObject)
@@ -64,9 +64,9 @@ type
 		function CanDisable: boolean;
 		function CanUpgrade: boolean;
 		function Dependency: TArray<TMarketItem>;
-   public
-      constructor Create;
-      destructor Destroy(); override;
+	public
+		constructor Create;
+		destructor Destroy(); override;
 	end;
 	TMarketList = TList<TMarketItem>;
 	TMarketDict = TDictionary<string, TMarketItem>;
@@ -126,20 +126,20 @@ implementation
 
 procedure MarketListClear;
 var
-   Item: TMarketItem;
+	Item: TMarketItem;
 begin
-   for Item In MarketList do
-      Item.Free;
-   MarketList.Clear;
+	for Item In MarketList do
+		Item.Free;
+	MarketList.Clear;
 end;
 
 procedure MarketListFree;
 var
-   Item: TMarketItem;
+	Item: TMarketItem;
 begin
-   for Item In MarketList do
-      Item.Free;
-   MarketList.Free;
+	for Item In MarketList do
+		Item.Free;
+	MarketList.Free;
 end;
 
 function GetItemPathINI: string;
@@ -196,7 +196,7 @@ begin
 	text := TStringList.Create;
 	for item in list do text.Append(item);
 	init.WriteString(KEY_ZYLO, KEY_LIST, text.DelimitedText);
-   text.Free;
+	text.Free;
 	init.Free;
 end;
 
@@ -220,7 +220,7 @@ end;
 
 destructor TMarketItem.Destroy;
 begin
-   use.Free;
+	use.Free;
 end;
 
 function TMarketItem.name: string;
@@ -297,7 +297,6 @@ begin
 	raise Exception.Create('checksum');
 end;
 var
-	msg: string;
 	Item: TMarketItem;
 begin
 	for Item in Dependency do begin
@@ -306,8 +305,7 @@ begin
 			Update(Item);
 			Verify(Item);
 		except
-			msg := 'download failed: ' + Item.ref;
-			MessageDlg(msg, mtWarning, [mbOK], 0);
+			TaskMessageDlg('download failed', Item.ref, mtWarning, [mbOK], 0);
 		end;
 	end;
 end;
@@ -356,9 +354,8 @@ var
 begin
 	if CanInstall then Exit(false);
 	for Item in Dependency do
-      if Test(Item) then Exit(true);
-
-   Result := False;
+		if Test(Item) then Exit(true);
+	Result := False;
 end;
 
 function TMarketItem.Dependency: TArray<TMarketItem>;

--- a/zlog/UzLogExtension.pas
+++ b/zlog/UzLogExtension.pas
@@ -996,13 +996,13 @@ end;
 procedure TButtonBridge.Handle(Sender: TObject);
 begin
 	Target.ButtonEvent(Number, Number);
-	Parent(Sender);
+	if @Parent <> nil then Parent(Sender);
 end;
 
 procedure TEditorBridge.Handle(Sender: TObject; var Key: char);
 begin
 	Target.EditorEvent(Number, integer(key));
-	Parent(Sender, key);
+	if @Parent <> nil then Parent(Sender, key);
 end;
 
 function TScriptOp.Int(num: extended): integer;

--- a/zlog/UzLogExtension.pas
+++ b/zlog/UzLogExtension.pas
@@ -82,7 +82,7 @@ type
 	/// event handler of button components.
 	/// </summary>
 	TButtonBridge = class
-		Source: TButton;
+		Source: TComponent;
 		Target: TDLL;
 		Number: integer;
 		Parent: TNotifyEvent;
@@ -490,19 +490,26 @@ end;
 /// </returns>
 function ButtonCallBack(f: PAnsiChar): integer; stdcall;
 var
-	Source: TButton;
+	Source: TComponent;
 	Bridge: TButtonBridge;
 begin
 	Inc(handlerNum);
 	Result := handlerNum;
-	Source := TButton(GetUI(CtoD(f)));
+	Source := TComponent(GetUI(CtoD(f)));
 	if (Source <> nil) and (LastDLL <> nil) then begin
 		Bridge := TButtonBridge.Create;
 		Bridge.Source := Source;
 		Bridge.Target := LastDLL;
 		Bridge.Number := Result;
-		Bridge.Parent := Source.OnClick;
-		Source.OnClick := Bridge.Handle;
+		if Source is TButton then begin
+			var comp := TButton(Source);
+			Bridge.Parent := comp.OnClick;
+			comp.OnClick := Bridge.Handle;
+		end else if Source is TMenuItem then begin
+			var comp := TMenuItem(Source);
+			Bridge.Parent := comp.OnClick;
+			comp.OnClick := Bridge.Handle;
+		end;
 	end;
 end;
 

--- a/zlog/UzLogExtension.pas
+++ b/zlog/UzLogExtension.pas
@@ -164,7 +164,7 @@ procedure AccessCallBack(f: PAnsiChar); stdcall;
 function HandleCallBack(f: PAnsiChar): THandle; stdcall;
 function ButtonCallBack(f: PAnsiChar): integer; stdcall;
 function EditorCallBack(f: PAnsiChar): integer; stdcall;
-function ScriptCallBack(f: PAnsiChar): boolean; stdcall;
+function ScriptCallBack(f: PAnsiChar): integer; stdcall;
 
 function DtoC(str: string): PAnsiChar;
 function CtoD(str: PAnsiChar): string;
@@ -544,17 +544,22 @@ end;
 /// </param>
 ///
 /// <returns>
-/// true for success
+/// 1 for success,
+/// 0 for failure,
+/// or the value of an integer expression
 /// <returns>
-function ScriptCallBack(f: PAnsiChar): boolean; stdcall;
+function ScriptCallBack(f: PAnsiChar): integer; stdcall;
 begin
 	try
-		RunScript(CtoD(f));
-		Result := True;
+		var value := RunScript(CtoD(f));
+		if value.IsOrdinal then
+			Result := value.AsInteger
+		else
+			Result := 1;
 	except
 		on e: Exception do begin
 			TaskMessageDlg(e.Message, CtoD(f), mtError, [mbOk], 0);
-			Result := False;
+			Result := 0;
 		end;
 	end;
 end;

--- a/zlog/UzLogExtension.pas
+++ b/zlog/UzLogExtension.pas
@@ -1064,6 +1064,7 @@ begin
 		QueryFormat(@FormatCallBack);
 		if not LaunchEvent then NotifyMismatch;
 		Rules.Add(ExtractFileName(path), Self);
+		MainForm.PluginMenu.Visible := True;
 	except
 		LastDLL := nil;
 	end;

--- a/zlog/main.dfm
+++ b/zlog/main.dfm
@@ -5963,6 +5963,10 @@ object MainForm: TMainForm
         OnClick = mnMergeClick
       end
     end
+    object PluginMenu: TMenuItem
+      Caption = '&Plugins'
+      Visible = False
+    end
     object View1: TMenuItem
       Caption = '&View'
       object ShowCurrentBandOnly: TMenuItem

--- a/zlog/main.pas
+++ b/zlog/main.pas
@@ -200,6 +200,7 @@ type
     H1: TMenuItem;
     CheckCall1: TMenuItem;
     CreateDupeCheckSheetZPRINT1: TMenuItem;
+    PluginMenu: TMenuItem;
     View1: TMenuItem;
     ShowCurrentBandOnly: TMenuItem;
     menuSortByTime: TMenuItem;


### PR DESCRIPTION
ご無沙汰しております。

今回、ZyLOによるプラグインから、zLog側の`TComponent`のメソッドやプロパティにアクセスするための改修をしましたので、そのPRを送ります。

## 趣旨

このPR以前でも、Windows APIを利用して、zLogのUIに手を加えることは可能でしたが、`TComponent`のメソッドやプロパティを無視していたため、賢明な方法ではありませんでした。そこで、メソッドやプロパティを参照するためのスクリプト実行環境をzLogに内蔵させ、DLLからは式の文字列を渡すことで、メソッドやプロパティを参照できるように改修します。

## 変更点

- `RunScript`関数の追加。この関数が、スクリプト実行の本体。
- `zylo_allow_script`関数の追加。この関数により、DLL側にスクリプト実行用のコールバック関数が渡される。
- Pluginsメニューの追加。普段は非表示だが、プラグインをインストールすると、自動的にメニューバーに追加される。
- `OnClick`のDLL側イベントハンドラを`TButton`だけでなく`TMenuItem`にも設定可能に。
- 警告ダイアログの表示を少し変更。具体的には、`MessageDlg`の代わりに`TaskMessageDlg`を使う。
- 関数のドキュメントの整備。

## スクリプト実行環境

Delphiの標準ライブラリである[TBindingExpression](https://docwiki.embarcadero.com/Libraries/Sydney/en/System.Bindings.Expression.TBindingExpression)を利用するため、特に外部のライブラリを必要としません。ただし、Delphiの非常に小さなサブセットであるため、多くの制約があります。

- コンストラクタを呼び出すことができない。
- 配列リテラルが使用できない。
- 文字列リテラルはダブルクォーテーションで囲う。
- プロパティに直接代入する構文が使えない。

このような制約を回避するには、[DWScript](https://github.com/EricGrange/DWScript)を使うことも考えられますが、現時点では、必要な機能を見極めるため、zLog本体に対する変更が少なくて済むTBindingExpressionを選択しました。

## スクリプトの実行方法

DLL側からは`RunDelphi`関数によりスクリプトを実行できます。
ただし、実行できるのは、式だけです。
また、式の返り値が整数の場合は、その値が`RunDelphi`関数の値となります。
そうでない場合は、エラーなく実行を完了できた場合は1が、エラーがあった場合は0が値となります。

```go
package main

func init() {
	OnLaunchEvent = onLaunchEvent
}

func onLaunchEvent() {
	RunDelphi(`PluginMenu.Add(op.Put(MainMenu.CreateMenuItem(), "Name", "MyMenu"))`)
	RunDelphi(`op.Put(MainMenu.FindComponent("MyMenu"), "Caption", "Special Menu")`)
}
```

詳細は既に[ドキュメント化](https://zylo.pafelog.net/manual)してあります。

## スクリプトを使用したプラグインの例

[JG1VPP/menu](https://github.com/JG1VPP/menu)

[`menu.dll`](https://github.com/JG1VPP/menu/releases/tag/nightly)を[`zlog.exe` (v2.8.3.0z7)](https://github.com/nextzlog/zlog/releases/tag/v2.8.3.0z7)と同じディレクトリに配置して、`zlog.ini`に以下の2行を追記することで試すことができます。

```ini
[zylo]
DLLs=menu.dll
```

zLogを起動すると、Pluginsメニューが表示されます。
その中にあるSpecial Menuというメニュー項目をクリックすることで、ダイアログが表示されます。