### PR TITLE
Localize Plugins Menu

### DIFF
--- a/zlog/ENU/main.dfm
+++ b/zlog/ENU/main.dfm
@@ -5963,6 +5963,10 @@ object MainForm: TMainForm
         OnClick = mnMergeClick
       end
     end
+    object PluginMenu: TMenuItem
+      Caption = '&Plugins'
+      Visible = False
+    end
     object View1: TMenuItem
       Caption = '&View'
       object ShowCurrentBandOnly: TMenuItem

--- a/zlog/JPN/main.dfm
+++ b/zlog/JPN/main.dfm
@@ -5963,6 +5963,11 @@ object MainForm: TMainForm
         OnClick = mnMergeClick
       end
     end
+    object PluginMenu: TMenuItem
+      Caption = '&Plugins'
+      Caption = #12503#12521#12464#12452#12531'(&P)'
+      Visible = False
+    end
     object View1: TMenuItem
       Caption = #34920#31034'(&V)'
       object ShowCurrentBandOnly: TMenuItem


### PR DESCRIPTION
PR #345 にて国際化対応にPluginsメニューが漏れていたので、修正します。次のリビジョンで取り入れていただければ助かります。

ビルド: [zLog v2.8.3.0z8](https://github.com/nextzlog/zlog/releases/tag/v2.8.3.0z8)

@jucky154 この修正で総務APIとEスポ情報プラグインが日本語でも正しく動作するはずです。