### PR TITLE
コンテストを開いた時にZyLOに通知する

### DIFF
--- a/zlog/ENU/UPluginManager.dfm
+++ b/zlog/ENU/UPluginManager.dfm
@@ -88,7 +88,7 @@ object MarketForm: TMarketForm
       Width = 614
       Height = 18
       Align = alBottom
-      Caption = '<a href="https://zylo.pafelog.net">How to make plugin</a>'
+      Caption = '<a href="https://nextzlog.github.io/zylo">How to make plugin</a>'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clWindowText
       Font.Height = -12

--- a/zlog/JPN/UPluginManager.dfm
+++ b/zlog/JPN/UPluginManager.dfm
@@ -88,7 +88,7 @@ object MarketForm: TMarketForm
       Width = 614
       Height = 18
       Align = alBottom
-      Caption = '<a href="https://zylo.pafelog.net">'#12503#12521#12464#12452#12531#12398#20316#12426#26041'</a>'
+      Caption = '<a href="https://nextzlog.github.io/zylo">How to make plugin</a>'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clWindowText
       Font.Height = -12

--- a/zlog/UPackageLoader.pas
+++ b/zlog/UPackageLoader.pas
@@ -1,8 +1,3 @@
-{*******************************************************************************
- * Amateur Radio Operational Logging Software 'ZyLO' since 2020 June 22
- * License: The MIT License since 2021 October 28 (see LICENSE)
- * Author: Journal of Hamradio Informatics (http://pafelog.net)
-*******************************************************************************}
 unit UPackageLoader;
 
 interface

--- a/zlog/UPluginManager.dfm
+++ b/zlog/UPluginManager.dfm
@@ -88,7 +88,7 @@ object MarketForm: TMarketForm
       Width = 614
       Height = 18
       Align = alBottom
-      Caption = '<a href="https://zylo.pafelog.net">How to make plugin</a>'
+      Caption = '<a href="https://nextzlog.github.io/zylo">How to make plugin</a>'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clWindowText
       Font.Height = -12

--- a/zlog/UPluginManager.pas
+++ b/zlog/UPluginManager.pas
@@ -1,8 +1,3 @@
-{*******************************************************************************
- * Amateur Radio Operational Logging Software 'ZyLO' since 2020 June 22
- * License: The MIT License since 2021 October 28 (see LICENSE)
- * Author: Journal of Hamradio Informatics (http://pafelog.net)
-*******************************************************************************}
 unit UPluginManager;
 
 interface
@@ -89,6 +84,7 @@ type
 		InstallButton: TButton;
 		DisableButton: TButton;
 		UpgradeButton: TButton;
+		procedure Browse(name: string);
 		procedure FormCreate(Sender: TObject);
 		procedure FormShow(Sender: TObject);
 		procedure LoadText(url: string; var txt: string);
@@ -129,6 +125,7 @@ var
 begin
 	for Item In MarketList do
 		Item.Free;
+	MarketDict.Clear;
 	MarketList.Clear;
 end;
 
@@ -341,6 +338,14 @@ begin
 	for Item in Self.use do list.Add(MarketDict[Item]);
 	Result := list.ToArray;
 	list.Free;
+end;
+
+procedure TMarketForm.Browse(name: string);
+begin
+	Show;
+	for var Item in MarketList do
+		if TPath.GetFileName(Item.ref) = name then
+			ListBox.Selected[MarketList.IndexOf(Item)] := true;
 end;
 
 procedure TMarketForm.FormCreate(Sender: TObject);

--- a/zlog/main.pas
+++ b/zlog/main.pas
@@ -2213,6 +2213,11 @@ begin
       FRateDialog.UpdateGraph();
       FRateDialogEx.UpdateGraph();
       dmZLogGlobal.Settings.FLastFileFilterIndex := OpenDialog.FilterIndex;
+      
+      if MyContest.ClassType = TGeneralContest then
+        zyloContestOpened(MyContest.Name, TGeneralContest(MyContest).Config.FileName)
+      else
+        zyloContestOpened(MyContest.Name, '');
    end;
 end;
 


### PR DESCRIPTION
ご無沙汰しております。以下3点の変更PRです。

- メニューバーからコンテストを開き直した時にプラグイン側に通知漏れがあった問題を修正
- CFGファイルが指定するプラグインが未インストールの場合にプラグインマネージャを開く
- ZyLO仕様書URLの変更